### PR TITLE
macOS group id conflicts

### DIFF
--- a/deploy/manager/Dockerfile
+++ b/deploy/manager/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get install -yq \
 ## Set up home directory
 ARG UID=1000
 ARG GID=1000
-RUN groupadd -g $GID murphy
+RUN groupadd -o -g $GID murphy
 RUN useradd -m -u $UID -g $GID -s /bin/bash murphy
 WORKDIR /home/murphy
 


### PR DESCRIPTION
This would prevent the issue described in #415 

This is definitely a little scary security wise, but anything else seems significantly more complicated.

If this solution is what we want though, it should be added to the other repos as well:
robokop-interfaces/deploy/Dockerfile 
robokop-rank/deploy/ranker/Dockerfile