### PR TITLE
fixing bug where support edges stopped showing up

### DIFF
--- a/src/components/answerset/AnswersetTableSubComponent.jsx
+++ b/src/components/answerset/AnswersetTableSubComponent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col, ButtonGroup, Button, Modal, OverlayTrigger, Popover } from 'react-bootstrap';
+import { ButtonGroup, Button, Modal, OverlayTrigger, Popover } from 'react-bootstrap';
 import { observer } from 'mobx-react';
 import { observable, action } from 'mobx';
 import { DropdownList } from 'react-widgets';

--- a/src/stores/messageAnswersetStore.js
+++ b/src/stores/messageAnswersetStore.js
@@ -321,6 +321,7 @@ class AnswersetStore {
       const kgNodeIdToKgNodeIndMap = {};
 
       graph = toJS(graph);
+
       // Iterate through each node in knowledgeGraph and score them
       graph.nodes.forEach((n, i) => {
         kgNodeIdToKgNodeIndMap[n.id] = i; // Store map of kGNodeId to kGNodeInd
@@ -488,8 +489,10 @@ class AnswersetStore {
       let nodes = [];
       let isSet = true;
 
-      if (!Array.isArray(nodeIds)) {
-        nodes = [{ id: nodeIds }];
+      if (!qNode.set) {
+        // if the node is not a set but is still an array
+        const nodeId = Array.isArray(nodeIds) ? nodeIds[0] : nodeIds;
+        nodes = [{ id: nodeId }];
         isSet = false;
         // Node is not a set
         // We will make it an array so we can follow the same code path


### PR DESCRIPTION
The bug came from a change in the message being sent to the front end. Node bindings in the answers used to be arrays for set nodes and strings for not, but now they're all arrays. This fix gets the question graph node and checks the 'set' boolean flag. If the node isn't a set, we either take the node binding string (for backwards compatibility) or the first element of the array of bindings (even if there are more, the node isn't a set).