### PR TITLE
Updated Dockerfile to work with provided install instruction.

### DIFF
--- a/deploy/manager/Dockerfile
+++ b/deploy/manager/Dockerfile
@@ -29,7 +29,7 @@ RUN useradd -m -u $UID -g $GID -s /bin/bash murphy
 WORKDIR /home/murphy
 
 ## Get ROBOKOP software
-ADD ./requirements.txt /home/murphy/requirements.txt
+ADD deploy/manager/requirements.txt /home/murphy/requirements.txt
 RUN pip install -r /home/murphy/requirements.txt --src /usr/local/src
 RUN git clone https://github.com/NCATS-Gamma/robokop.git
 ## Set up the website


### PR DESCRIPTION
Changed where the default location of requirements.txt is listed, as the current Docker build command is 

$ cd robokop/
$ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t robokop_manager -f deploy/manager/Dockerfile .

Which should be 2 directories above.